### PR TITLE
[Glense][DevOps] Enable `git pp` to add username prefix to branches 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ When you first clone the repository, run the setup script to install the pre-com
 
 # Git PP
 
-Using `git pp` you can automatically add your branch as a prefix when pushing the current branch. 
-If your branch is `fix-bugs` and you setup username to John with `./setup-pp.sh John` pushed branched should look like:
-`John/fix-bugs`
+Using `git pp` you can automatically add your username as a prefix when pushing the current branch. 
+Example:
+If your branch is called `fix-bugs` and you setup username to John using `./setup-pp.sh John` - pushed branched should look like this: `John/fix-bugs`
 
 ```bash
 # Make sure you're in the repository root

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ When you first clone the repository, run the setup script to install the pre-com
 ./scripts/setup-hooks.sh
 ```
 
+# Git PP
+
+Using `git pp` you can automatically add your branch as a prefix when pushing the current branch. 
+If your branch is `fix-bugs` and you setup username to John with `./setup-pp.sh John` pushed branched should look like:
+`John/fix-bugs`
+
+```bash
+# Make sure you're in the repository root
+./scripts/setup-pp.sh username
+```
+
+
 This project includes a pre-commit hook that automatically formats C# code before each commit.
 
 The hook will automatically run and format your C# code. If any files are modified by formatting, the commit will be blocked and you'll need to stage the formatted files and commit again.

--- a/scripts/setup-pp.sh
+++ b/scripts/setup-pp.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if branch prefix argument is provided
+if [ $# -eq 0 ]; then
+    echo "Error: Branch prefix argument is required"
+    echo "Usage: $0 <branch-prefix>"
+    echo "Example: $0 brankonymous"
+    exit 1
+fi
+
+# Configuration
+BRANCH_PREFIX="$1"
+
+# Setup git alias for pushing to specified branch prefix
+git config alias.pp "!f() { bname=\$(git rev-parse --abbrev-ref HEAD); git push origin HEAD:${BRANCH_PREFIX}/\$bname; }; f"
+
+echo "Git alias 'pp' has been configured successfully!"
+echo "Usage: git pp"
+echo "This will push your current branch to origin/${BRANCH_PREFIX}/<current-branch-name>"


### PR DESCRIPTION
Using `git pp` you can automatically add your username as a prefix when pushing the current branch. 
Example:
If your branch is called `fix-bugs` and you setup username to John using `./setup-pp.sh John` - pushed branched should look like this: `John/fix-bugs`
